### PR TITLE
Bundle CPU .so even when building CUDA backend

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -13,7 +13,6 @@ pushd build/cpu
 cmake ${CMAKE_ARGS} -DCOMPUTE_BACKEND=cpu -GNinja ../..
 ninja
 popd
-rm -rf build/cpu
 
 # CUDA enabled build. This will create libbitsandbytes_cuda.so
 # Even in a CUDA build we will still bundle the _cpu.so as a fallback if no GPUs are available
@@ -23,7 +22,6 @@ if [[ "${cuda_compiler_version:-None}" != "None" ]]; then
   cmake ${CMAKE_ARGS} -DCOMPUTE_BACKEND=cuda -GNinja ../..
   ninja
   popd
-  rm -rf build/cuda
 fi
 
 # This will automatically pull in all .so files we've built

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -2,16 +2,30 @@
 
 set -exuo pipefail
 
-if [[ "${cuda_compiler_version:-None}" != "None" ]]; then
-  export CMAKE_ARGS="${CMAKE_ARGS} -DCOMPUTE_BACKEND=cuda"
-else
-  export CMAKE_ARGS="${CMAKE_ARGS} -DCOMPUTE_BACKEND=cpu"
-fi
+# bitsandbytes' cmake config will produce only one .so per backend build
+# but we always need the generic "cpu" backend even for CUDA-enabled builds or import will fail
+# if in an environment with CUDA but without a GPU
 
-mkdir -p build
-pushd build
-cmake ${CMAKE_ARGS} -GNinja ..
+# Build the generic "cpu" backend
+# this will create libbitsandbytes_cpu.so in the the bitsandbytes folder
+mkdir -p build/cpu
+pushd build/cpu
+cmake ${CMAKE_ARGS} -DCOMPUTE_BACKEND=cpu -GNinja ../..
 ninja
 popd
+rm -rf build/cpu
 
+# CUDA enabled build. This will create libbitsandbytes_cuda.so
+# Even in a CUDA build we will still bundle the _cpu.so as a fallback if no GPUs are available
+if [[ "${cuda_compiler_version:-None}" != "None" ]]; then
+  mkdir -p build/cuda
+  pushd build/cuda
+  cmake ${CMAKE_ARGS} -DCOMPUTE_BACKEND=cuda -GNinja ../..
+  ninja
+  popd
+  rm -rf build/cuda
+fi
+
+# This will automatically pull in all .so files we've built
+# on a CPU only build this will only be one .so, on CUDA both the CPU and CUDA variants
 pip install --no-deps --no-build-isolation -vvv .

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,11 +7,11 @@ package:
 
 source:
   # Don't use the PyPI source tarball as this already contains compiled code.
-  url: https://github.com/TimDettmers/bitsandbytes/archive/refs/tags/{{ version }}.tar.gz
+  url: https://github.com/bitsandbytes-foundation/bitsandbytes/archive/refs/tags/{{ version }}.tar.gz
   sha256: 7a468bc977da19c176cc578954bfd7a3c64182f387a6849e9f0a38d5cba1b4df
 
 build:
-  number: 1
+  number: 2
   string: cuda{{ cuda_compiler_version | replace('.', '') }}_py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [cuda_compiler_version != "None"]
   string: cpu_py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [cuda_compiler_version == "None"]
   skip: true  # [not linux]
@@ -48,11 +48,14 @@ test:
     - pip
 
 about:
-  home: https://github.com/TimDettmers/bitsandbytes
-  summary: k-bit optimizers and matrix multiplication routines.
+  home: https://github.com/bitsandbytes-foundation/bitsandbytes
+  summary: The bitsandbytes library is a lightweight Python wrapper around CUDA custom functions, in particular 8-bit optimizers, matrix multiplication (LLM.int8()), and 8 & 4-bit quantization functions.
   license: MIT
   license_file: LICENSE
 
 extra:
   recipe-maintainers:
     - xhochy
+    - iamthebot
+    - shaowei-su
+    - snapbug


### PR DESCRIPTION
In #14 we fixed the CUDA .so file not being included in CUDA enabled builds. However, one problem is that `bitsandbytes` relies on both the presence of CUDA libraries *and* a GPU working w/ that CUDA version to detect which native lib to load.

On a system with CUDA installed but without a GPU this will cause problems because we don't bundle in the non-CUDA .so in the conda package in that case. We encountered during an import of `bitsandbytes` on a Ray head node.

This modifies the build to always build the `libbitsandbytes_cpu.so` even during a CUDA enabled build. This enables non-GPU fallback to work correctly.

I've also added two fellow contributors willing to do some maintenance work on this feedstock.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
